### PR TITLE
Fixed typo on CustomEvent properties.

### DIFF
--- a/prism-data-table.html
+++ b/prism-data-table.html
@@ -456,7 +456,7 @@
                 // Fire sort event
                 this.dispatchEvent(new CustomEvent('sort', {
                     bubble: true,
-                    compose: true,
+                    composed: true,
                     detail: Object.assign({ direction: this.get('sortDirection') }, column)
                 }));
             }


### PR DESCRIPTION
One of the properties in the CustomEvent sort has a typo, **compose should be composed**. Because of this, the event is not propagated outside the custom element shadow DOM